### PR TITLE
Switch to Esri World Imagery

### DIFF
--- a/lib/providers/settings.dart
+++ b/lib/providers/settings.dart
@@ -46,7 +46,7 @@ class Settings with ChangeNotifier {
       case "satellite":
         return TileLayerOptions(
             urlTemplate:
-                'https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryOnly/MapServer/tile/{z}/{y}/{x}',
+                'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
             tileProvider: makeTileProvider(name),
             maxNativeZoom: 20,
             opacity: (opacity ?? _mapOpacity["satellite"] ?? 1.0) * 0.8 + 0.2);


### PR DESCRIPTION
The satellite view was causing an error in debug mode only.
Apparently because of unavailable zoom level at the location asked (France). Map is just blank in release mode.
- [ ] Ideally this would need to be confirmed for complete understanding, my debugging approach was fairly experimental.

I adopted a less subtle approach and looked for another map provider to compare.
From https://leaflet-extras.github.io/leaflet-providers/preview/, using Esri.WorldImagery worked out of the box per my tests.
- [ ] I don’t know if maxNativeZoom should be adapted, and how?

In addition to providing full zoom for France, I find the new satellite view to be more precise in California (contrast and details). I’m not saying accurate because I don’t know about the age of the views in both providers.