### PR TITLE
Revamped the wind estimation logic

### DIFF
--- a/lib/providers/wind.dart
+++ b/lib/providers/wind.dart
@@ -4,6 +4,15 @@ import 'package:flutter/material.dart';
 import 'package:xcnav/models/vector.dart';
 import 'package:xcnav/util.dart';
 
+/// Result of a wind solution.
+///
+/// Units
+/// - airspeed: meters/second (m/s)
+/// - windSpd: meters/second (m/s)
+/// - windHdg: radians, normalized to [0, 2π)
+/// - circleCenter: cartesian center (m/s) of fitted speed circle
+/// - maxSpd: max observed groundspeed scaled by 1.1 (for plotting)
+/// - timestamp: wall-clock time when the solve completed
 class WindSolveResult {
   late final double airspeed;
   late final double windSpd;
@@ -15,62 +24,343 @@ class WindSolveResult {
   late final DateTime timestamp;
   List<double> samplesX;
   List<double> samplesY;
-  WindSolveResult(this.airspeed, this.windSpd, this.windHdg, this.circleCenter, this.maxSpd, this.samplesX,
-      this.samplesY, this.timestamp);
+  WindSolveResult(
+    this.airspeed,
+    this.windSpd,
+    this.windHdg,
+    this.circleCenter,
+    this.maxSpd,
+    this.samplesX,
+    this.samplesY,
+    this.timestamp,
+  );
 }
 
 class Wind with ChangeNotifier {
-  /// Recorded
-  List<Vector> samples = [];
+  Wind({bool isRunningReplayFromLog = false}) : _isRunningReplayFromLog = isRunningReplayFromLog;
+
+  /// Recorded ground vectors: heading (rad) and speed (m/s).
+  List<Vector> _samples = [];
+  List<Vector> get samples => _samples;
 
   /// Most recent wind calculation performed
   WindSolveResult? _result;
   WindSolveResult? get result => _result;
 
-  static const maxSampleAge = Duration(minutes: 15);
+  /// True when feeding samples from an offline log replay.
+  final bool _isRunningReplayFromLog;
 
+  /// Logging verbosity; higher prints more. Only active during log replay.
+  int _printVerbosity = 0;
+
+  /// Configure the logging verbosity for this instance.
+  void setPrintVerbosity(int v) => _printVerbosity = v;
+
+  /// Internal logging helper that respects verbosity and replay state.
+  void _log(String msg, {int v = 1}) {
+    if (_isRunningReplayFromLog && v <= _printVerbosity) {
+      debugPrint(msg);
+      //print(msg); // This collates with the unit test's prints to screen than debugPrint
+    }
+  }
+
+  // ================== Tunable thresholds ==================
+  /// Minimum samples required to attempt convergence.
+  static const int _minSamplesForConvergence = 4;
+
+  /// Required field-of-view (radians) across headings for a valid solve.
+  static const double _fovThresholdRad = 80 * (pi / 180); // 80°
+
+  /// Maximum plausible windspeed and airspeed
+  static const double _maxPlausibleWindspeedMph = 120;
+  static const double _maxPlausibleAirspeedMph = 63;
+
+  /// Convergence residual tolerance as a fraction of radius (airspeed).
+  /// All used samples must be within this to be considered converged.
+  static const double _convergeResidualRel = 0.70; // ±70%
+
+  /// When converged, new samples must fit within this relative residual to be accepted.
+  static const double _convergedAcceptResidualRel = 0.50; // ±50%
+
+  /// Unconverged: drop only obviously bad points with residual beyond this relative amount
+  /// (applied after a tentative fit if available).
+  static const double _obviousErrantResidualRel = 1.5; // >±150%
+
+  /// Aging windows for keeping samples.
+  static const Duration _expireUnconverged = Duration(minutes: 10);
+  static const Duration _expireConverged = Duration(minutes: 10);
+
+  /// If converged and no applicable samples for this long, fall back to unconverged
+  /// and stop reporting until reconverged.
+  static const Duration _staleConvergedTimeout = Duration(minutes: 5);
+
+  /// Always drop the older sample if a new one arrives within this heading span.
+  static const double _dedupeAngleRad = 3 * pi / 180; // 3°
+  /// Require at least this many newer samples within the span before dropping an older one.
+  static const int _dedupeMinNewerCount = 3;
+
+  /// Remaining headway downwind given course-to-wind `theta` and speeds.
+  /// Guards sqrt for small negative inputs from FP error.
   static double remainingHeadway(double theta, double mySpd, double wSpd) =>
-      sqrt(pow(mySpd, 2) - pow(wSpd * sin(theta), 2)) - cos(theta) * wSpd;
+      sqrt(max(0, pow(mySpd, 2) - pow(wSpd * sin(theta), 2))) - cos(theta) * wSpd;
 
+  /// Clear any computed result and recorded samples.
   void clearResult() {
     _result = null;
-    samples.clear();
+    _samples.clear();
     notifyListeners();
   }
 
+  /// Ingest a new ground vector sample and attempt to solve for wind.
+  ///
+  /// Behavior
+  /// - Trims very old samples when timestamps are present (older than [maxSampleAge]).
+  /// - Requires >4 samples and field-of-view >90° before solving for stability.
+  /// - Notifies listeners when a new result is produced.
   void handleVector(Vector newSample) {
-    samples.add(newSample);
-    while (samples.isNotEmpty &&
-        (samples.first.timestamp != null && samples.first.timestamp!.isBefore(DateTime.now().subtract(maxSampleAge)))) {
-      // Remove 10 at a time for performance
-      samples.removeRange(0, min(10, samples.length));
+
+    // When replaying from a log, prefer the sample's timestamp; otherwise use wall clock time.
+    final DateTime now = (_isRunningReplayFromLog && newSample.timestamp != null)
+        ? newSample.timestamp!
+        : DateTime.now();
+
+    // If converged but stale (no accepted samples for a while), reset and start over.
+    if (_converged && _lastAccepted != null && now.difference(_lastAccepted!) > _staleConvergedTimeout) {
+      _log('Wind: state -> UNCONVERGED (stale > ${_staleConvergedTimeout.inMinutes}m). Dropping samples older than 5m', v: 1);
+      _converged = false;
+      _result = null; // stop reporting
+      _samples.clear();
+      notifyListeners();
     }
 
-    if (samples.length > 4) {
-      // Check sampled field-of-view is sufficient for confidence
-      double prev = samples.first.hdg;
-      double left = prev;
-      double right = prev;
-      for (Vector each in samples) {
-        final cur = prev + deltaHdg(each.hdg, prev);
+    // Trim samples by current state aging policy.
+    _expireOlderThan(now.subtract(_converged ? _expireConverged : _expireUnconverged));
 
-        left = min(left, cur);
-        right = max(right, cur);
-        prev = cur;
+    // Dedupe by heading: always drop older samples within 3° of the new heading.
+    _dropOlderWithinHeading(newSample.hdg, _dedupeAngleRad);
+
+    bool accepted = false;
+
+    if (_converged && _result != null) {
+      // Check if new sample fits current circle within ±40%.
+      final r = _result!;
+      final residual = _residualForSample(newSample, r.circleCenter, r.airspeed);
+      final rel = residual / max(1e-6, r.airspeed);
+      if (rel <= _convergedAcceptResidualRel) {
+        _samples.add(newSample);
+        accepted = true;
+        _lastAccepted = now;
+        _attemptConverge(now); // refine fit while staying converged
       }
-      final fov = right - left;
-      // debugPrint("FOV: $fov  (${samples.length} samples)");
-
-      if (fov > pi / 2) solve(samples);
+      // If not accepted, keep sample out; if we remain stale, state will flip above.
+      else {
+        final hdgDeg = (newSample.hdg * 180 / pi) % 360;
+        _log('Wind: drop sample (converged non-compliance) residualRel=${rel.toStringAsFixed(2)} hdg=${hdgDeg.toStringAsFixed(1)}° spd=${newSample.value.toStringAsFixed(2)}m/s', v: 2);
+      }
     } else {
+      // Unconverged: only reject obviously errant samples, otherwise accept.
+      if (_isSaneSample(newSample)) {
+        _samples.add(newSample);
+        accepted = true;
+        _lastAccepted = now;
+        _attemptConverge(now);
+      } else {
+        final hdgDeg = (newSample.hdg * 180 / pi) % 360;
+        _log('Wind: drop sample (invalid) hdg=${hdgDeg.toStringAsFixed(1)}° spd=${newSample.value.toStringAsFixed(2)}m/s', v: 2);
+      }
+    }
+
+    // If we didn't accept and are unconverged, ensure no result is reported.
+    if (!_converged) {
       _result = null;
-      notifyListeners();
+      if (accepted) notifyListeners();
     }
   }
 
-  /// #Solve wind direction from GPS samples.
-  /// https://people.cas.uab.edu/~mosya/cl/
-  void solve(List<Vector> samples) {
+  // ================== State & helpers ==================
+  bool _converged = false;
+  DateTime? _lastAccepted;
+
+  /// Remove samples with timestamps older than the cutoff.
+  void _expireOlderThan(DateTime cutoff) {
+    if (_samples.isEmpty) return;
+    final before = _samples.length;
+    _samples.removeWhere((s) => s.timestamp != null && s.timestamp!.isBefore(cutoff));
+    final expired = before - _samples.length;
+    if (expired > 0) {
+      _log('Wind: expired $expired old sample(s); remaining ${_samples.length}', v: 3);
+    }
+  }
+
+  /// Drop older samples near the given heading if sufficiently represented by newer ones.
+  void _dropOlderWithinHeading(double hdg, double angleRad) {
+    if (_samples.isEmpty) return;
+
+    // Collect candidate indices near the heading
+    final candidates = <int>[];
+    for (int ii = 0; ii < _samples.length; ii++) {
+      final each = _samples[ii];
+      if (deltaHdg(each.hdg, hdg).abs() <= angleRad) {
+        candidates.add(ii);
+      }
+    }
+    if (candidates.isEmpty) return;
+
+    // For each candidate, count newer ones in the same span; drop if enough newer exist
+    final toRemove = <int>[];
+    for (final ii in candidates) {
+      int newer = 0;
+      for (final jj in candidates) {
+        if (jj > ii) newer++;
+      }
+      if (newer >= _dedupeMinNewerCount) {
+        toRemove.add(ii);
+      }
+    }
+
+    if (toRemove.isEmpty) return;
+    toRemove.sort((a, b) => b.compareTo(a));
+    for (final idx in toRemove) {
+      _samples.removeAt(idx);
+    }
+    final hdgDeg = (hdg * 180 / pi) % 360;
+    _log('Wind: removed ${toRemove.length} near-duplicate older sample(s) within '
+        '${(angleRad * 180 / pi).toStringAsFixed(1)}° of hdg=${hdgDeg.toStringAsFixed(1)}° '
+        '(minNewer=$_dedupeMinNewerCount)', v: 3);
+  }
+
+  bool _isSaneSample(Vector v) {
+    return v.value.isFinite && v.value > 0 && v.value < 90 && v.hdg.isFinite;
+  }
+
+  /// Try to converge given current samples/time. Sets _converged/_result as appropriate.
+  void _attemptConverge(DateTime now) {
+    final wasConverged = _converged;
+
+    if (_samples.length < _minSamplesForConvergence) return;
+
+    final fov = _computeFov(_samples);
+    if (fov < _fovThresholdRad) {
+        if (wasConverged) {
+            _log('Wind: state -> UNCOVERGED due to field of view ${fov.toStringAsFixed(2)} < ${_fovThresholdRad.toStringAsFixed(2)}', v: 1);
+        } else {
+            _log('Wind: Not converging due to field of view ${fov.toStringAsFixed(2)} < ${_fovThresholdRad.toStringAsFixed(2)}', v: 3);
+        }
+        _result = null;
+        _converged = false;
+        return;
+    }
+
+    final res = _solve(_samples, now, applyGates: true);
+    if (res == null) {
+        // Either the wind speed or the air speed have gotten implausible.  Just reset and start over.
+        if (wasConverged) {
+            _log('Wind: state -> UNCOVERGED due to _solve plausibility checks', v: 1);
+        }
+        _result = null;
+        _converged = false;
+        _samples.clear();
+        return;
+    }
+
+    final residuals = _computeResiduals(_samples, res.circleCenter, res.airspeed);
+    final maxRel = residuals
+        .map((e) => e / max(1e-6, res.airspeed))
+        .fold<double>(0, (prev, cur) => cur > prev ? cur : prev);
+
+    if (maxRel <= _convergeResidualRel) {
+      _result = res;
+      _converged = true;
+      _lastAccepted ??= now;
+      notifyListeners();
+      if (!wasConverged) {
+        final hdgDeg = (res.windHdg * 180 / pi) % 360;
+        _log('Wind: state -> CONVERGED with ${_samples.length} samples | '
+            'air=${res.airspeed.toStringAsFixed(2)}m/s wind=${res.windSpd.toStringAsFixed(2)}m/s '
+            'hdg=${hdgDeg.toStringAsFixed(1)}°', v: 1);
+      }
+    } else {
+      _log('Wind: Not converging due to residual error ${maxRel.toStringAsFixed(2)} > ${_convergeResidualRel.toStringAsFixed(2)}', v: 3);
+
+      // Not converged: only drop obviously errant points.
+      final toKeep = <Vector>[];
+      for (int ii = 0; ii < _samples.length; ii++) {
+        final rel = residuals[ii] / max(1e-6, res.airspeed);
+        if (rel <= _obviousErrantResidualRel) toKeep.add(_samples[ii]);
+      }
+      if (toKeep.isNotEmpty && toKeep.length != _samples.length) {
+        final dropped = _samples.length - toKeep.length;
+        _samples = toKeep;
+        _log('Wind: removed $dropped obvious outlier sample(s) while unconverged', v: 2);
+      }
+    }
+  }
+
+  /// Compute the minimal circular arc (field-of-view) that contains all headings.
+  ///
+  /// Robust to wrap-around across 0°/360°. Order-independent.
+  /// Returns radians in [0, 2π]. A value ≥ π/2 means at least 90° of spread.
+  double _computeFov(List<Vector> samples) {
+    if (samples.isEmpty) return 0;
+    if (samples.length == 1) return 0;
+
+    // Normalize headings to [0, 2π) and sort
+    final angles = samples
+        .map((v) => ((v.hdg % (2 * pi)) + 2 * pi) % (2 * pi))
+        .toList()
+      ..sort();
+
+    // Find the largest gap between consecutive angles (including wrap gap)
+    // Then, the fov is 2pi minus the gap
+
+    // Start with the wraparound gap of the smallest and largest angles
+    double maxGap = (angles.first + 2 * pi) - angles.last;
+    for (int ii = 1; ii < angles.length; ii++) {
+      final gap = angles[ii] - angles[ii - 1];
+      if (gap > maxGap) {
+          maxGap = gap;
+      }
+    }
+    // The minimal arc length covering all angles is 2π - largest gap.
+    return (2 * pi) - maxGap;
+  }
+
+  /// Compute residual distances from each sample point to the fitted circle.
+  List<double> _computeResiduals(List<Vector> vectors, Offset center, double radius) {
+    final cx = center.dx;
+    final cy = center.dy;
+    final out = <double>[];
+    for (final v in vectors) {
+      final x = cos(v.hdg - pi / 2) * v.value;
+      final y = sin(v.hdg - pi / 2) * v.value;
+      final dist = sqrt(pow(x - cx, 2) + pow(y - cy, 2));
+      out.add((dist - radius).abs());
+    }
+    return out;
+  }
+
+  /// Compute residual for a single sample to the fitted circle.
+  double _residualForSample(Vector v, Offset center, double radius) {
+    final cx = center.dx;
+    final cy = center.dy;
+    final x = cos(v.hdg - pi / 2) * v.value;
+    final y = sin(v.hdg - pi / 2) * v.value;
+    final dist = sqrt(pow(x - cx, 2) + pow(y - cy, 2));
+    return (dist - radius).abs();
+  }
+
+  /// Solve wind vector and airspeed from ground speed/heading samples.
+  ///    returns a solution or null. When [applyGates] is true,
+  ///
+  /// Method
+  /// - Project polar measurements (hdg, speed) into cartesian (x,y) in m/s.
+  /// - Remove DC offset, then fit a circle via Newton–Taubin.
+  /// - Circle center => wind vector; radius => airspeed.
+  /// - Applies plausibility gates (wind speed and radius constraints).
+  ///
+  /// Reference: https://people.cas.uab.edu/~mosya/cl/
+  ///
+  WindSolveResult? _solve(List<Vector> samples, DateTime now, {required bool applyGates}) {
     // debugPrint("Solve Wind");
     double mXX = 0;
     double mYY = 0;
@@ -79,17 +369,17 @@ class Wind with ChangeNotifier {
     double mYZ = 0;
     double mZZ = 0;
 
-    // Transform to cartesian
+    // Transform to cartesian. Note the -π/2 rotation aligns 0 rad to +Y.
     final samplesX = samples.map((e) => cos(e.hdg - pi / 2) * e.value).toList();
     final samplesY = samples.map((e) => sin(e.hdg - pi / 2) * e.value).toList();
     final maxSpd = samples.reduce((a, b) => a.value > b.value ? a : b).value * 1.1;
 
-    // Remove DC offset (translate to cener over origin)
+    // Remove DC offset (translate to center over origin).
     final xMean = samplesX.reduce((a, b) => a + b) / samplesX.length;
     final yMean = samplesY.reduce((a, b) => a + b) / samplesY.length;
-    for (int i = 0; i < samplesX.length; i++) {
-      final xI = samplesX[i] - xMean;
-      final yI = samplesY[i] - yMean;
+    for (int ii = 0; ii < samplesX.length; ii++) {
+      final xI = samplesX[ii] - xMean;
+      final yI = samplesY[ii] - yMean;
       final zI = xI * xI + yI * yI;
       mXY += xI * yI;
       mXX += xI * xI;
@@ -130,6 +420,10 @@ class Wind with ChangeNotifier {
         break;
       }
       double dY = a1 + xnew * (a22 + xnew * a33);
+      if (!dY.isFinite || dY == 0) {
+        xnew = 0;
+        break;
+      }
       double xold = xnew;
       xnew = xold - ynew / dY;
       if (((xnew - xold) / xnew).abs() < epsilon) break;
@@ -143,21 +437,38 @@ class Wind with ChangeNotifier {
       }
     }
 
-    // compute final offset and radius
+    // Compute final offset and radius of the fitted circle.
     final det = xnew * xnew - xnew * mZ + covXY;
+    if (!det.isFinite || det.abs() < 1e-12) {
+      return null;
+    }
     double xCenter = (mXZ * (mYY - xnew) - mYZ * mXY) / det / 2;
     double yCenter = (mYZ * (mXX - xnew) - mXZ * mXY) / det / 2;
-    final radius = sqrt(pow(xCenter, 2) + pow(yCenter, 2) + mZ);
+    final radius = sqrt(max(0, pow(xCenter, 2) + pow(yCenter, 2) + mZ));
     xCenter += xMean;
     yCenter += yMean;
-    final windSpd = sqrt(pow(xCenter, 2) + pow(yCenter, 2));
-    final windHdg = atan2(xCenter, -yCenter) % (2 * pi);
+    final windSpd = sqrt(max(0, pow(xCenter, 2) + pow(yCenter, 2)));
+    // Align heading to [0, 2π). atan2 uses x/y per our coordinate transform.
+    final windHdg = (atan2(xCenter, -yCenter) + 2 * pi) % (2 * pi);
 
-    // More conditions for good result
-    if (windSpd < 90 && radius < 40) {
-      _result = WindSolveResult(
-          radius, windSpd, windHdg, Offset(xCenter, yCenter), maxSpd, samplesX, samplesY, DateTime.now());
-      notifyListeners();
+    // Confidence gates: limit implausible wind and radius.
+
+    final maxPlausibleWindspeedMps = _maxPlausibleWindspeedMph / 2.23694;
+    final maxPlausibleAirspeedMps = _maxPlausibleAirspeedMph / 2.23694;
+
+    if (applyGates) {
+      if (!(windSpd < maxPlausibleWindspeedMps && radius < maxPlausibleAirspeedMps)) return null;
     }
+
+    return WindSolveResult(
+      radius,
+      windSpd,
+      windHdg,
+      Offset(xCenter, yCenter),
+      maxSpd,
+      samplesX,
+      samplesY,
+      now,
+    );
   }
 }

--- a/scripts/run_wind_test.bat
+++ b/scripts/run_wind_test.bat
@@ -1,0 +1,26 @@
+@echo off
+setlocal ENABLEDELAYEDEXPANSION
+
+REM Validate exactly one argument
+if "%~1"=="" goto :usage
+if not "%~2"=="" goto :usage
+
+REM Validate file exists
+if not exist "%~1" (
+  echo Error: File not found: %~1
+  exit /b 66
+)
+
+set "XCNAV_LOG=%~1"
+echo Using XCNAV_LOG="%XCNAV_LOG%"
+
+REM Run the wind unit test
+flutter test test\wind_from_json_test.dart
+set EXITCODE=%ERRORLEVEL%
+exit /b %EXITCODE%
+
+:usage
+echo Usage: %~n0 path\to\flight_log.json
+echo Example: %~n0 C:\logs\my_flight.json
+exit /b 64
+

--- a/test/wind_from_json_test.dart
+++ b/test/wind_from_json_test.dart
@@ -1,0 +1,82 @@
+
+// This is a unit test to pump a flight log (*.json file) through
+// the wind estimator and print out the results onscreen
+
+// Just set the environment varable XCNAV_LOG to the location of the file and then run
+// > flutter test test/wind_from_json_test.dart
+
+// On Windows, you can call a batch script that makes this easy:
+// > run_wind_test.bat <path\to\log.json>
+
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xcnav/models/flight_log.dart';
+import 'package:xcnav/models/vector.dart';
+import 'package:xcnav/providers/wind.dart';
+
+void main() {
+  test('Wind solve from flight log', () async {
+    final path = Platform.environment['XCNAV_LOG'];
+    expect(path, isNotNull, reason: 'Set env var XCNAV_LOG to a .json flight log');
+    final file = File(path!);
+    expect(await file.exists(), isTrue, reason: 'File not found: $path');
+
+    final content = await file.readAsString();
+    final data = jsonDecode(content) as Map<String, dynamic>;
+    final log = FlightLog.fromJson(path, data, rawJson: content);
+
+
+    final int logStartTimeSec = log.samples.first.time ~/ 1000;
+
+    final wind = Wind(isRunningReplayFromLog: true);
+
+    int successfulWindReports = 0;
+    // Print every time a new wind result is solved.
+    wind.addListener(() {
+      final r = wind.result;
+      if (r != null) {
+        final windSpeed = r.windSpd;
+        final hdgDeg = (r.windHdg * 180 / pi) % 360;
+        final airSpeed = r.airspeed;
+
+        // Speeds are in m/s
+        // For knots, multiply by 1.943844
+        // For kph, multiply by 3.6
+        // For mph, multiply by 2.23694
+        final windSpeedMph = windSpeed * 2.23694;
+        final airSpeedMph = airSpeed * 2.23694;
+
+        // Elapsed minutes from first to latest log entry
+        final int latestTimeSec = r.timestamp.millisecondsSinceEpoch ~/ 1000.0;
+        final double elapsedMin = (latestTimeSec - logStartTimeSec) / 60.0;
+
+        successfulWindReports++;
+
+        print('${elapsedMin.toStringAsFixed(1)}m: windSpeed=${windSpeedMph.toStringAsFixed(2)}mph '
+              'hdg=${hdgDeg.toStringAsFixed(1)}° airSpeed=${airSpeedMph.toStringAsFixed(2)}mph');
+      }
+    });
+
+    // Feed samples including altitude and timestamp from the log.
+    for (final geo in log.samples) {
+      if (geo.spd > 1) {
+        wind.handleVector(Vector(
+          geo.hdg,
+          geo.spd,
+          alt: geo.alt,
+          timestamp: DateTime.fromMillisecondsSinceEpoch(geo.time),
+        ));
+      }
+    }
+
+    final double reportPct = 100.0 * successfulWindReports / log.samples.length;
+    print('Got a wind report for ${reportPct.toStringAsFixed(1)}% of the samples');
+
+    // Pass criteria: require wind reports for > 50%% of samples
+    expect(reportPct, greaterThan(50.0),
+        reason: 'Insufficient wind reports; require > 50% coverage.');
+  });
+}


### PR DESCRIPTION

* Revamped the wind estimation logic.  The underlying math is the same, but
  added a bunch of surrounding logic to better control it.

* It's now based on a "converged vs non-converged" state machine.  There are criteria for adding and keeping samples to be used for adaptation in each case.

* The field-of-view logic wasn't quite right, so that was reworked.

* Will now delete samples that are more than well represented by newer ones.

* All tunable parameters are moved to the top for easy tuning.

* Added a unit test that takes in a *.json log file from a flight and dumps all outputs

* Fully tested with the unit test by sending about 10+ real flight logs through, and the improvements are dramatic.

* Verified with "flutter analyze" that the code is all still compatible with the app

* DID NOT TEST in the context of the app. My puny slow computer wasn't able to run the Android simulator very well.