### PR TITLE
Gps alt changes 20251104

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -44,6 +44,7 @@
             "right_hand_ui": "Right-handed UI",
             "always_show_pilot_names": "Always Show Pilot Names",
             "hide_wind_observations": "Hide Wind Observations",
+            "use_gps_altitude": "Use GPS Only for Altitude",
             "group_view_includes_waypoints": "Group View Includes Waypoints",
             "Distance": "Distance",
             "Speed": "Speed",

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -45,6 +45,7 @@
             "always_show_pilot_names": "Always Show Pilot Names",
             "hide_wind_observations": "Hide Wind Observations",
             "use_gps_altitude": "Use GPS Only for Altitude",
+            "gps_update_interval": "GPS Update Interval (ms)",
             "group_view_includes_waypoints": "Group View Includes Waypoints",
             "Distance": "Distance",
             "Speed": "Speed",

--- a/assets/translations/hu.json
+++ b/assets/translations/hu.json
@@ -44,6 +44,7 @@
             "right_hand_ui": "Jobbkezes felhasználói felület",
             "always_show_pilot_names": "Pilótanevek mindig látszanak",
             "hide_wind_observations": "Szélmegfigyelések elrejtése",
+            "use_gps_altitude": "Csak GPS használata magasságméréshez",
             "group_view_includes_waypoints": "A csoportnézet tartalmazza az útvonalpontokat",
             "Distance": "Távolság",
             "Speed": "Sebesség",

--- a/assets/translations/hu.json
+++ b/assets/translations/hu.json
@@ -45,6 +45,7 @@
             "always_show_pilot_names": "Pilótanevek mindig látszanak",
             "hide_wind_observations": "Szélmegfigyelések elrejtése",
             "use_gps_altitude": "Csak GPS használata magasságméréshez",
+            "gps_update_interval": "GPS frissítési intervallum (ms)",
             "group_view_includes_waypoints": "A csoportnézet tartalmazza az útvonalpontokat",
             "Distance": "Távolság",
             "Speed": "Sebesség",

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -44,6 +44,7 @@
       "right_hand_ui": "Интерфейс для правшей",
       "always_show_pilot_names": "Показывать имена пилотов",
       "hide_wind_observations": "Скрыть наблюдения за ветром",
+      "use_gps_altitude": "Использовать GPS только для определения высоты",
       "group_view_includes_waypoints": "Путевые точки на экране группы",
       "Distance": "Расстояние",
       "Speed": "Скорость",

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -45,6 +45,7 @@
       "always_show_pilot_names": "Показывать имена пилотов",
       "hide_wind_observations": "Скрыть наблюдения за ветром",
       "use_gps_altitude": "Использовать GPS только для определения высоты",
+      "gps_update_interval": "Интервал обновления GPS (мс)",
       "group_view_includes_waypoints": "Путевые точки на экране группы",
       "Distance": "Расстояние",
       "Speed": "Скорость",

--- a/lib/models/geo.dart
+++ b/lib/models/geo.dart
@@ -46,7 +46,7 @@ class Geo {
     time = timestamp ?? DateTime.now().millisecondsSinceEpoch;
   }
 
-  Geo.fromPosition(Position location, Geo? prev, BarometerEvent? baro, BarometerEvent? baroAmbient) {
+  Geo.fromPosition(Position location, Geo? prev, BarometerEvent? baro, BarometerEvent? baroAmbient, {bool useGpsAltitude = false}) {
     lat = location.latitude;
     lng = location.longitude;
     time = location.timestamp.millisecondsSinceEpoch;
@@ -67,11 +67,12 @@ class Geo {
       hdg = prev?.hdg ?? location.heading;
     }
 
-    if (baro != null) {
-      // altitude / vario filtering
-      alt = altFromBaro(baro.pressure, baroAmbient?.pressure);
-    } else {
+    if (useGpsAltitude || baro == null) {
+      // Use GPS altitude when explicitly requested or when barometer is unavailable
       alt = location.altitude;
+    } else {
+      // altitude / vario filtering with barometer
+      alt = altFromBaro(baro.pressure, baroAmbient?.pressure);
     }
   }
 

--- a/lib/providers/my_telemetry.dart
+++ b/lib/providers/my_telemetry.dart
@@ -719,20 +719,15 @@ class MyTelemetry with ChangeNotifier, WidgetsBindingObserver {
 
     speedSmooth.value = speedSmooth.value * 0.8 + geo!.spd * 0.2;
 
-    recordGeo.add(geo!);
-
-    // Notify listeners immediately so GPS altitude updates without delay
-    notifyListeners();
-
-    // Fetch ground elevation asynchronously without blocking
-    sampleDem(geo!.latlng, true).then((value) {
+    await sampleDem(geo!.latlng, true).then((value) {
       if (value != null) {
         geo!.ground = value;
-        notifyListeners(); // Notify again when ground elevation is available
       }
     }).timeout(const Duration(milliseconds: 1000), onTimeout: () {
       warn("DEM service timeout", attributes: {"lat": geo!.lat, "lng": geo!.lng});
     });
+
+    recordGeo.add(geo!);
 
     // fetch ambient baro from weather service
     if (baroAmbient == null && baroAmbientRequestCount < 10) {
@@ -790,6 +785,8 @@ class MyTelemetry with ChangeNotifier, WidgetsBindingObserver {
         saveFlight();
       }
     }
+
+    notifyListeners();
   }
 
   Polyline buildFlightTrace() {

--- a/lib/providers/my_telemetry.dart
+++ b/lib/providers/my_telemetry.dart
@@ -398,7 +398,7 @@ class MyTelemetry with ChangeNotifier, WidgetsBindingObserver {
             accuracy: LocationAccuracy.best,
             distanceFilter: 0,
             forceLocationManager: false,
-            intervalDuration: const Duration(seconds: 3),
+            intervalDuration: const Duration(milliseconds: 500),
             foregroundNotificationConfig: const ForegroundNotificationConfig(
                 notificationText: "Still sending your position to the group.",
                 notificationTitle: "xcNav",
@@ -698,9 +698,9 @@ class MyTelemetry with ChangeNotifier, WidgetsBindingObserver {
 
   void updateGeo(Position position, {bool bypassRecording = false}) async {
     geoPrev = geo;
-    geo = Geo.fromPosition(position, geoPrev, baro, baroAmbient);
-    if (baro == null) {
-      // Maybe no barometer in device?
+    geo = Geo.fromPosition(position, geoPrev, baro, baroAmbient, useGpsAltitude: settingsMgr.useGpsAltitude.value);
+    if (baro == null || settingsMgr.useGpsAltitude.value) {
+      // Use GPS-based vario when barometer unavailable or GPS-only mode enabled
       if (geoPrev != null) {
         final vario = (geo!.alt - geoPrev!.alt) / (geo!.time - geoPrev!.time) * 1000;
         if (vario.isFinite) {

--- a/lib/providers/my_telemetry.dart
+++ b/lib/providers/my_telemetry.dart
@@ -398,7 +398,7 @@ class MyTelemetry with ChangeNotifier, WidgetsBindingObserver {
             accuracy: LocationAccuracy.best,
             distanceFilter: 0,
             forceLocationManager: false,
-            intervalDuration: const Duration(milliseconds: 2000),
+            intervalDuration: Duration(milliseconds: settingsMgr.gpsUpdateInterval.value),
             foregroundNotificationConfig: const ForegroundNotificationConfig(
                 notificationText: "Still sending your position to the group.",
                 notificationTitle: "xcNav",

--- a/lib/screens/settings_editor.dart
+++ b/lib/screens/settings_editor.dart
@@ -200,6 +200,16 @@ class _SettingsEditorState extends State<SettingsEditor> {
                                               trailing = Switch.adaptive(
                                                   value: value as bool, onChanged: (value) => e.config!.value = value);
                                               break;
+                                            case "int":
+                                              trailing = SizedBox(
+                                                width: 80,
+                                                child: TextFormField(
+                                                    textAlign: TextAlign.center,
+                                                    keyboardType: TextInputType.number,
+                                                    initialValue: (value as int).toString(),
+                                                    onChanged: (value) => e.config!.value = int.tryParse(value) ?? 0),
+                                              );
+                                              break;
                                             case "double":
                                               trailing = SizedBox(
                                                 width: 80,

--- a/lib/settings_service.dart
+++ b/lib/settings_service.dart
@@ -375,7 +375,7 @@ class SettingsMgr {
     showServoCarbMenu = SettingConfig(this, prefs, "Experimental", "showServoCarbMenu", false,
         title: "show_servocarb", icon: const Icon(Icons.settings_applications_sharp));
     useGpsAltitude = SettingConfig(this, prefs, "Experimental", "useGpsAltitude", false,
-        title: "Use GPS Only for Altitude",
+        title: "use_gps_altitude",
         icon: const Icon(Icons.satellite_alt),
         description: "Ignore barometric pressure and use GPS MSL altitude for all calculations.");
 

--- a/lib/settings_service.dart
+++ b/lib/settings_service.dart
@@ -231,6 +231,7 @@ class SettingsMgr {
   late final SettingConfig<double> barometerOffset;
   late final SettingConfig<bool> showServoCarbMenu;
   late final SettingConfig<bool> useGpsAltitude;
+  late final SettingConfig<int> gpsUpdateInterval;
 
   // --- Debug Tools
   late final SettingConfig<bool> spoofLocation;
@@ -378,6 +379,11 @@ class SettingsMgr {
         title: "use_gps_altitude",
         icon: const Icon(Icons.satellite_alt),
         description: "Ignore barometric pressure and use GPS MSL altitude for all calculations.");
+    gpsUpdateInterval = SettingConfig(this, prefs, "Experimental", "gpsUpdateInterval", 3000,
+        title: "gps_update_interval",
+        icon: const Icon(Icons.speed),
+        description: "GPS update interval in milliseconds (Android only). Lower values use more battery.",
+        setter: (value) => value < 500 ? 500 : value);
 
     // --- Debug Tools
     spoofLocation = SettingConfig(this, prefs, "Debug Tools", "", false,

--- a/lib/settings_service.dart
+++ b/lib/settings_service.dart
@@ -383,7 +383,8 @@ class SettingsMgr {
         title: "gps_update_interval",
         icon: const Icon(Icons.speed),
         description: "GPS update interval in milliseconds (Android only). Lower values use more battery.",
-        setter: (value) => value < 500 ? 500 : value);
+        setter: (value) => value < 500 ? 500 : value,
+        hidden: defaultTargetPlatform != TargetPlatform.android);
 
     // --- Debug Tools
     spoofLocation = SettingConfig(this, prefs, "Debug Tools", "", false,

--- a/lib/settings_service.dart
+++ b/lib/settings_service.dart
@@ -230,6 +230,7 @@ class SettingsMgr {
   // --- ServoCarb
   late final SettingConfig<double> barometerOffset;
   late final SettingConfig<bool> showServoCarbMenu;
+  late final SettingConfig<bool> useGpsAltitude;
 
   // --- Debug Tools
   late final SettingConfig<bool> spoofLocation;
@@ -373,6 +374,10 @@ class SettingsMgr {
         description: "Add offset to barometer reading for calibration.");
     showServoCarbMenu = SettingConfig(this, prefs, "Experimental", "showServoCarbMenu", false,
         title: "show_servocarb", icon: const Icon(Icons.settings_applications_sharp));
+    useGpsAltitude = SettingConfig(this, prefs, "Experimental", "useGpsAltitude", false,
+        title: "Use GPS Only for Altitude",
+        icon: const Icon(Icons.satellite_alt),
+        description: "Ignore barometric pressure and use GPS MSL altitude for all calculations.");
 
     // --- Debug Tools
     spoofLocation = SettingConfig(this, prefs, "Debug Tools", "", false,

--- a/lib/views/view_elevation.dart
+++ b/lib/views/view_elevation.dart
@@ -125,73 +125,76 @@ class ViewElevationState extends State<ViewElevation> with AutomaticKeepAliveCli
               ),
 
             // --- Barometer control
-            ListTile(
-              minVerticalPadding: 20,
-              visualDensity: VisualDensity.compact,
-              // leading: const Icon(Icons.thermostat),
-              title: Text("Ambient Pressure".tr()),
-              trailing: Row(mainAxisSize: MainAxisSize.min, children: [
-                IconButton(
-                    visualDensity: VisualDensity.compact,
-                    onPressed: () {
-                      if (myTelemetry.geo != null) {
-                        myTelemetry.snapBarometerTo(settingsMgr.ambientPressureSource.value,
-                            latlng: myTelemetry.geo?.latlng);
-                      }
-                    },
-                    iconSize: 18,
-                    icon: settingsMgr.ambientPressureSource.value == BarometerSrc.weatherkit
-                        ? (myTelemetry.baroFromWeatherkit
-                            ? const Icon(Icons.public, color: Colors.lightGreen)
-                            : const Icon(
-                                Icons.public_off,
-                                color: Colors.red,
-                              ))
-                        : Icon(Icons.refresh)),
-                Text(
-                  printDouble(value: myTelemetry.baroAmbient?.pressure ?? 1013.25, digits: 4, decimals: 2),
-                  style:
-                      TextStyle(fontSize: 20, color: myTelemetry.baroFromWeatherkit ? Colors.lightGreen : Colors.white),
-                ),
-                VerticalDivider(
-                  color: Colors.grey.shade900,
-                ),
-                IconButton(
-                    visualDensity: VisualDensity.compact,
-                    onPressed: () => {
-                          setState(() {
-                            myTelemetry.baroFromWeatherkit = false;
-                            myTelemetry.baroAmbient =
-                                BarometerEvent((myTelemetry.baroAmbient?.pressure ?? 1013.25) + 0.25, clock.now());
-                          })
-                        },
-                    icon: const Icon(
-                      Icons.add_circle,
-                      size: 20,
-                    )),
-                IconButton(
-                    visualDensity: VisualDensity.compact,
-                    onPressed: () => {
-                          setState(() {
-                            myTelemetry.baroFromWeatherkit = false;
-                            myTelemetry.baroAmbient =
-                                BarometerEvent((myTelemetry.baroAmbient?.pressure ?? 1013.25) - 0.25, clock.now());
-                          })
-                        },
-                    icon: const Icon(
-                      Icons.remove_circle,
-                      size: 20,
-                    )),
-              ]),
-            ),
+            if (!settingsMgr.useGpsAltitude.value)
+              ListTile(
+                minVerticalPadding: 20,
+                visualDensity: VisualDensity.compact,
+                // leading: const Icon(Icons.thermostat),
+                title: Text("Ambient Pressure".tr()),
+                trailing: Row(mainAxisSize: MainAxisSize.min, children: [
+                  IconButton(
+                      visualDensity: VisualDensity.compact,
+                      onPressed: () {
+                        if (myTelemetry.geo != null) {
+                          myTelemetry.snapBarometerTo(settingsMgr.ambientPressureSource.value,
+                              latlng: myTelemetry.geo?.latlng);
+                        }
+                      },
+                      iconSize: 18,
+                      icon: settingsMgr.ambientPressureSource.value == BarometerSrc.weatherkit
+                          ? (myTelemetry.baroFromWeatherkit
+                              ? const Icon(Icons.public, color: Colors.lightGreen)
+                              : const Icon(
+                                  Icons.public_off,
+                                  color: Colors.red,
+                                ))
+                          : Icon(Icons.refresh)),
+                  Text(
+                    printDouble(value: myTelemetry.baroAmbient?.pressure ?? 1013.25, digits: 4, decimals: 2),
+                    style:
+                        TextStyle(fontSize: 20, color: myTelemetry.baroFromWeatherkit ? Colors.lightGreen : Colors.white),
+                  ),
+                  VerticalDivider(
+                    color: Colors.grey.shade900,
+                  ),
+                  IconButton(
+                      visualDensity: VisualDensity.compact,
+                      onPressed: () => {
+                            setState(() {
+                              myTelemetry.baroFromWeatherkit = false;
+                              myTelemetry.baroAmbient =
+                                  BarometerEvent((myTelemetry.baroAmbient?.pressure ?? 1013.25) + 0.25, clock.now());
+                            })
+                          },
+                      icon: const Icon(
+                        Icons.add_circle,
+                        size: 20,
+                      )),
+                  IconButton(
+                      visualDensity: VisualDensity.compact,
+                      onPressed: () => {
+                            setState(() {
+                              myTelemetry.baroFromWeatherkit = false;
+                              myTelemetry.baroAmbient =
+                                  BarometerEvent((myTelemetry.baroAmbient?.pressure ?? 1013.25) - 0.25, clock.now());
+                            })
+                          },
+                      icon: const Icon(
+                        Icons.remove_circle,
+                        size: 20,
+                      )),
+                ]),
+              ),
 
-            Divider(
-              height: 0,
-              color: Colors.grey.shade900,
-            ),
+            if (!settingsMgr.useGpsAltitude.value)
+              Divider(
+                height: 0,
+                color: Colors.grey.shade900,
+              ),
 
             // --- Density Altitude
-            if (!myTelemetry.inFlight &&
+            if (!settingsMgr.useGpsAltitude.value &&
+                !myTelemetry.inFlight &&
                 myTelemetry.baroAmbient != null &&
                 myTelemetry.ambientTemperature != null &&
                 myTelemetry.geo != null)
@@ -230,7 +233,7 @@ class ViewElevationState extends State<ViewElevation> with AutomaticKeepAliveCli
                   ),
                   Text.rich(richValue(UnitType.distFine, myTelemetry.geo!.altGps,
                       digits: 6,
-                      decimals: -2,
+                      decimals: 0,
                       valueStyle: Theme.of(context).textTheme.headlineMedium,
                       unitStyle: const TextStyle(color: Colors.grey, fontStyle: FontStyle.italic)))
                 ]),


### PR DESCRIPTION
- Experimental setting to disable altitude determination from pressure sensor.  
- Lowered GPS updates by one second to speed up the android fused location provider thingy so altitude normalizes faster when going up/down quickly.  Battery impact should be minimal but no profiling was done. 
- Moved sampleDem to be non-blocking with subsequent listener notification when AGL info is updated.